### PR TITLE
Make MavenCoords constructor param "group" nullable and defaulted

### DIFF
--- a/commons-kt-kt/src/commonMain/kotlin/xyz/wagyourtail/commonskt/maven/MavenCoords.kt
+++ b/commons-kt-kt/src/commonMain/kotlin/xyz/wagyourtail/commonskt/maven/MavenCoords.kt
@@ -5,11 +5,9 @@ import kotlin.jvm.JvmInline
 @JvmInline
 value class MavenCoords(val value: String) {
 
-    constructor(group: String? = "", artifact: String, version: String? = null, classifier: String? = null, extension: String? = null): this(buildString {
-        if (group != null) {
-            append(group)
-            append(':')
-        }
+    constructor(group: String = "", artifact: String, version: String? = null, classifier: String? = null, extension: String? = null): this(buildString {
+        append(group)
+        append(':')
         append(artifact)
         if (version != null) {
             append(':')
@@ -30,28 +28,48 @@ value class MavenCoords(val value: String) {
         get() = value.substringBeforeLast('@').split(":", limit = 4)
 
     val group: String?
-        get() {
-            if (parts.size < 2) return null
-            return parts[0]
-        }
+        // ["", "artifact"] = null
+        // ["@extension", "artifact@extension"] = null
+        // ["group:artifact" ... "group:artifact:version:classifier" ...] = "group"
+        // ["group:artifact@extension" ... "group:artifact:version:classifier@extension" ...] = "group"
+        get() = if (parts.size < 2) null else parts[0]
 
     val artifact: String
-        get() {
-            if (parts.size < 2) return value
-            return parts[1]
-        }
+        // ["", "@extension"] = ""
+        // ["artifact", "artifact@extension"] = "artifact"
+        // ["group:artifact" ... "group:artifact:version:classifier" ...] = "artifact"
+        // ["group:artifact@extension" ... "group:artifact:version:classifier@extension" ...] = "artifact"
+        get() = if (parts.size < 2) value else parts[1]
 
     val version: String?
+        // ["" ... "group:artifact" ...] = null
+        // ["@extension" ... "group:artifact@extension" ...] = null
+        // ["group:artifact:version", "group:artifact:version:classifier" ...] = "version"
+        // ["group:artifact:version@extension", "group:artifact:version:classifier" ...] = "version"
         get() = parts.getOrNull(2)
 
     val classifier: String?
+        // ["" ... "group:artifact:version" ...] = null
+        // ["@extension" ... "group:artifact:version@extension" ...] = null
+        // ["group:artifact:version:classifier" ...] = "classifier"
+        // ["group:artifact:version:classifier@extension" ...] = "classifier"
         get() = parts.getOrNull(3)
 
     val extension: String
+        // ["" ... "group:artifact:version:classifier" ...] = "jar"
+        // "@extension" ... "group:artifact:version:classifier@extension" = "extension"
         get() = value.substringAfterLast('@', "jar")
 
 
     val fileName: String
+        // [("group:artifact")] = "artifact-unspecified.jar"
+        // [("group:artifact:version")] = "artifact-version.jar"
+        // [("group:artifact") { classifier = "classifier" }] = "artifact-unspecified-classifier.jar"
+        // [("group:artifact:version:classifier")] = "artifact-version-classifier.jar"
+        // [("group:artifact@extension")] = "artifact-unspecified.extension"
+        // [("group:artifact:version@extension")] = "artifact-version.extension"
+        // [("group:artifact@extension") { classifier = "classifier" }] = "artifact-unspecified-classifier.extension"
+        // [("group:artifact:version:classifier@extension")] = "artifact-version-classifier.extension"
         get() = buildString {
             append(artifact)
             append('-')

--- a/commons-kt-kt/src/commonMain/kotlin/xyz/wagyourtail/commonskt/maven/MavenCoords.kt
+++ b/commons-kt-kt/src/commonMain/kotlin/xyz/wagyourtail/commonskt/maven/MavenCoords.kt
@@ -57,7 +57,7 @@ value class MavenCoords(val value: String) {
 
     val extension: String
         // ["" ... "group:artifact:version:classifier" ...] = "jar"
-        // "@extension" ... "group:artifact:version:classifier@extension" = "extension"
+        // ["@extension" ... "group:artifact:version:classifier@extension"] = "extension"
         get() = value.substringAfterLast('@', "jar")
 
 

--- a/commons-kt-kt/src/commonMain/kotlin/xyz/wagyourtail/commonskt/maven/MavenCoords.kt
+++ b/commons-kt-kt/src/commonMain/kotlin/xyz/wagyourtail/commonskt/maven/MavenCoords.kt
@@ -5,9 +5,11 @@ import kotlin.jvm.JvmInline
 @JvmInline
 value class MavenCoords(val value: String) {
 
-    constructor(group: String, artifact: String, version: String? = null, classifier: String? = null, extension: String? = null): this(buildString {
-        append(group)
-        append(':')
+    constructor(group: String? = "", artifact: String, version: String? = null, classifier: String? = null, extension: String? = null): this(buildString {
+        if (group != null) {
+            append(group)
+            append(':')
+        }
         append(artifact)
         if (version != null) {
             append(':')


### PR DESCRIPTION
The nullability of the parameter should match the nullability of the property. It appears that the property is null if only one part is available. Which would mean that `name` is as valid as `group:name`.

Sometimes `:name:X.Y.Z` is a valid coordinate, so it can be left out when converted back to a string, too.

I committed this change to make it easier to clone a `MavenCoords` object and change part of it, such as when you want to add a `version` to it late.